### PR TITLE
Introduce configuration option for interrupt source

### DIFF
--- a/RemoteReceiver.cpp
+++ b/RemoteReceiver.cpp
@@ -5,10 +5,17 @@
 volatile uint8_t RemoteReceiver::ready;
 volatile uint32_t RemoteReceiver::data;
 
-void RemoteReceiver::start(uint8_t intr){
+#if REMOTE_RECEIVER_USE_ATTACH_INTERRUPT
+void RemoteReceiver::start(uint8_t intr)
+#else
+void RemoteReceiver::start()
+#endif
+{
   ready = 0;
   data = 0;
+#if REMOTE_RECEIVER_USE_ATTACH_INTERRUPT
   attachInterrupt(intr, &RemoteReceiver::interrupt, CHANGE);
+#endif
 }
 
 uint8_t RemoteReceiver::dataReady(){

--- a/RemoteReceiver.h
+++ b/RemoteReceiver.h
@@ -1,12 +1,22 @@
 #include <stdint.h>
 
+#ifndef REMOTE_RECEIVER_USE_ATTACH_INTERRUPT
+#define REMOTE_RECEIVER_USE_ATTACH_INTERRUPT 1
+#endif
+
 class RemoteReceiver{
   public:
+#if REMOTE_RECEIVER_USE_ATTACH_INTERRUPT
 	static void start(uint8_t intr);
+#else
+	static void start();
+#endif
 	static uint8_t dataReady();
 	static uint32_t getData();
 
+#if REMOTE_RECEIVER_USE_ATTACH_INTERRUPT
  private:
+#endif
    static void interrupt();
    static volatile uint8_t ready;
    static volatile uint32_t data;


### PR DESCRIPTION
This allows the library to be externally driven, which makes it
compatible with non-Arduino projects and projects where there's no
available interrupt.
